### PR TITLE
Proxy host for upstream

### DIFF
--- a/main.go
+++ b/main.go
@@ -63,6 +63,7 @@ func main() {
 		Director: func(r *http.Request) {
 			r.URL.Scheme = "http"
 			r.URL.Host = upstream
+			r.Host = r.URL.Host
 			if verbose {
 				fmt.Printf("UPSTREAM-REQUEST TO: %s\n", r.URL.String())
 			}


### PR DESCRIPTION
When Prometheus is behind web server virtual host it should be proxied with proper 'Host' header.
At this PR I propose to use upstream hostname.